### PR TITLE
using the correct gulp version reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "fs-extra": "^7.0.0",
     "glob": "^7.1.2",
     "graceful-fs": "^4.1.11",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "github:gulpjs/gulp#v4.0.0",
     "gulp-autoprefixer": "^5.0.0",
     "gulp-babel": "^7.0.1",
     "gulp-bump": "^3.0.0",


### PR DESCRIPTION
using the correct gulp version reference in `package.json` . Otherwise the installation fails with 

```
npm ERR! code 1
npm ERR! Command failed: C:\Program Files\Git\cmd\git.EXE checkout 4.0
npm ERR! error: pathspec '4.0' did not match any file(s) known to git
```